### PR TITLE
fix: add repository to checkout step in ci.yml

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,6 +10,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
 
       # Run a couple of native Terraform checks
       - uses: hashicorp/setup-terraform@v3


### PR DESCRIPTION
## what

* Add `repository` to `actions/checkout` step in `ci.yml`

## why
* Currently, the action will not work for PRs coming from forks, as it defaults to `github.repository`

## references
* Default value - https://github.com/actions/checkout/blob/cd7d8d697e10461458bc61a30d094dc601a8b017/action.yml#L6
* https://docs.github.com/en/webhooks/webhook-events-and-payloads?actionType=opened#pull_request
* Looks like this is a common issue
  * https://github.com/actions/checkout/issues/551
  * https://github.com/actions/checkout/issues/455 