### PR TITLE
chore: disable terraform-docs push when on forks and sign commit

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,6 +33,7 @@ jobs:
 
       # Terraform-docs
       - uses: terraform-docs/gh-actions@v1.1.0
+        id: terraform-docs
         with:
           working-dir: .
           output-file: README.md
@@ -53,3 +54,15 @@ jobs:
           file_pattern: 'README.md'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Print instructions to run terraform-docs locally if changes are needed and workflow is running on fork
+      - if: ${{ !cancelled() && github.repository_owner != 'runatlantis' && steps.terraform-docs.outputs.num_changed > 0 }}
+        run: |
+          echo '### Please run terraform-docs locally and commit the changes:' >> $GITHUB_STEP_SUMMARY
+          echo '' >> $GITHUB_STEP_SUMMARY
+          echo '```sh' >> $GITHUB_STEP_SUMMARY
+          echo 'docker run --rm --volume "$(pwd):/terraform-docs" -u $(id -u) quay.io/terraform-docs/terraform-docs:0.17.0 markdown --output-file README.md --output-mode inject /terraform-docs' >> $GITHUB_STEP_SUMMARY
+          echo 'git add README.md' >> $GITHUB_STEP_SUMMARY
+          echo 'git commit --amend --no-edit' >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          echo '' >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,6 +5,11 @@ on:
 jobs:
   ci:
     runs-on: ubuntu-latest
+    permissions:
+      # Give the default GITHUB_TOKEN write permission to commit and push the
+      # added or changed files to the repository.
+      contents: write
+
     steps:
       # Setup dependencies
       - uses: actions/checkout@v4
@@ -34,5 +39,17 @@ jobs:
           output-method: inject
           fail-on-diff: true
           args: --lockfile=false
-          git-push: "true" # automatically push the changes to the branch
+          git-push: 'false'
 
+      # Push Terraform-docs changes
+      - uses: planetscale/ghcommit-action@v0.1.35
+        # Run this step even if previous steps fails (there are changes to commit)
+        # but skip when on forks
+        if: ${{ !cancelled() && github.repository_owner == 'runatlantis' }}
+        with:
+          commit_message: "terraform-docs: automated action"
+          repo: ${{ github.repository }}
+          branch: ${{ github.head_ref || github.ref_name }}
+          file_pattern: 'README.md'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## what
* Disable terraform-docs push when on forks
* Use [`ghcommit-action`](https://github.com/planetscale/ghcommit-action) to create a verified commit and push the changes, instead of using terraform-docs' `git-push`, [which does not sign commits](https://github.com/terraform-docs/gh-actions/pull/110)
* Set `continue-on-error` to `true` since we only commit in the next step
* Add instructions to run tfdocs locally for forks in workflow summary

## why
* The `ci` workflow fails when running on forks because it fails to push changes (as it should): https://github.com/runatlantis/terraform-gce-atlantis/actions/runs/8737454606/job/24044031175
* The commits being signed/verified are really useful when people's forks live inside organizations that require signed commits (rebasing and pushing unsigned commits in the fork are blocked)

## references
* https://github.com/planetscale/ghcommit-action
* https://github.com/terraform-docs/gh-actions/issues/63#issuecomment-1898044297
* https://github.com/runatlantis/terraform-gce-atlantis/pull/149#issuecomment-2063869845
* Example run (pushes a commit, and status is failed): https://github.com/runatlantis/terraform-gce-atlantis/actions/runs/8760478846/job/24045502598