### PR TITLE
fix: google_logging_enabled variable now correctly passed to instance template

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -129,7 +129,7 @@ resource "google_compute_instance_template" "default" {
   metadata = {
     gce-container-declaration    = module.container.metadata_value
     user-data                    = data.cloudinit_config.config.rendered
-    google-logging-enabled       = var.google_monitoring_enabled
+    google-logging-enabled       = var.google_logging_enabled
     google-monitoring-enabled    = var.google_monitoring_enabled
     google-logging-use-fluentbit = var.google_logging_use_fluentbit
     block-project-ssh-keys       = var.block_project_ssh_keys_enabled


### PR DESCRIPTION
## what
*  google_logging_enabled variable now correctly passed to instance template

## why
* `google_monitoring_enabled` was used instead of `google_logging_enabled` to set the instance template `google-logging-enabled`

## references
* Close #129
