### PR TITLE
feat: add persistent_disk_type variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,7 @@ You can check the status of the certificate in the Google Cloud Console.
 | <a name="input_name"></a> [name](#input\_name) | Custom name that's used during resource creation | `string` | n/a | yes |
 | <a name="input_network"></a> [network](#input\_network) | Name of the network | `string` | n/a | yes |
 | <a name="input_persistent_disk_size_gb"></a> [persistent\_disk\_size\_gb](#input\_persistent\_disk\_size\_gb) | The size of the persistent disk that Atlantis uses to store its data on | `number` | `50` | no |
+| <a name="input_persistent_disk_type"></a> [persistent\_disk\_type](#input\_persistent\_disk\_type) | The type of persistent disk that Atlantis uses to store its data on | `string` | `"pd-ssd"` | no |
 | <a name="input_project"></a> [project](#input\_project) | The ID of the project in which the resource belongs | `string` | `null` | no |
 | <a name="input_region"></a> [region](#input\_region) | The region that resources should be created in | `string` | n/a | yes |
 | <a name="input_service_account"></a> [service\_account](#input\_service\_account) | Service account to attach to the instance running Atlantis | <pre>object({<br>    email  = string,<br>    scopes = list(string)<br>  })</pre> | <pre>{<br>  "email": "",<br>  "scopes": [<br>    "cloud-platform"<br>  ]<br>}</pre> | no |

--- a/main.tf
+++ b/main.tf
@@ -171,7 +171,7 @@ resource "google_compute_instance_template" "default" {
   #  Persistent disk for Atlantis
   disk {
     device_name  = "atlantis-disk-0"
-    disk_type    = "pd-ssd"
+    disk_type    = var.persistent_disk_type
     mode         = "READ_WRITE"
     disk_size_gb = var.persistent_disk_size_gb
     auto_delete  = false

--- a/variables.tf
+++ b/variables.tf
@@ -201,3 +201,9 @@ variable "shared_vpc" {
   })
   default = null
 }
+
+variable "persistent_disk_type" {
+  type        = string
+  description = "The type of persistent disk that Atlantis uses to store its data on"
+  default     = "pd-ssd"
+}


### PR DESCRIPTION
## what
* Add variable to allow changing the type of the persistent disk

## why
* The module forces users to use `pd-ssd`s

## references
* Close #158
