### PR TITLE
chore: fix terraform docs behavior

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -61,7 +61,7 @@ jobs:
           echo '### Please run terraform-docs locally and commit the changes:' >> $GITHUB_STEP_SUMMARY
           echo '' >> $GITHUB_STEP_SUMMARY
           echo '```sh' >> $GITHUB_STEP_SUMMARY
-          echo 'docker run --rm --volume "$(pwd):/terraform-docs" -u $(id -u) quay.io/terraform-docs/terraform-docs:0.17.0 markdown --output-file README.md --output-mode inject /terraform-docs' >> $GITHUB_STEP_SUMMARY
+          echo 'docker run --rm --volume "$(pwd):/terraform-docs" -u $(id -u) quay.io/terraform-docs/terraform-docs markdown --output-file README.md --output-mode inject /terraform-docs' >> $GITHUB_STEP_SUMMARY
           echo 'git add README.md' >> $GITHUB_STEP_SUMMARY
           echo 'git commit --amend --no-edit' >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY

--- a/.terraform-docs.yml
+++ b/.terraform-docs.yml
@@ -1,0 +1,5 @@
+settings:
+  # https://github.com/terraform-docs/gh-actions/issues/98
+  # Since we do not commit the lockfile, it has no effect in gh workflows.
+  # Changes local runs to match the gh workflow behavior.
+  lockfile: false


### PR DESCRIPTION
## what
* Remove version from docker run tf docs suggestion
* Set `lockfile: false` in terraform-docs settings

## why
* When running the suggested command to locally generate docs, there is a difference in behavior between local and remote (gh action) results, since locally it has access to the terraform lockfile.
* Since we do not commit the lockfile, it has no effect in gh workflows

## references
* https://github.com/terraform-docs/gh-actions/issues/98
