### PR TITLE
Fix pinning of machine_type #2

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ You can check the status of the certificate in the Google Cloud Console.
 | <a name="input_iap_backend_security_policy"></a> [iap\_backend\_security\_policy](#input\_iap\_backend\_security\_policy) | Name of the security policy to apply to the IAP backend service | `string` | `null` | no |
 | <a name="input_image"></a> [image](#input\_image) | Docker image. This is most often a reference to a container located in a container registry | `string` | `"ghcr.io/runatlantis/atlantis:latest"` | no |
 | <a name="input_labels"></a> [labels](#input\_labels) | Key-value pairs representing labels attaching to instance & instance template | `map(any)` | `{}` | no |
-| <a name="input_machine_image"></a> [machine\_image](#input\_machine\_image) | The machine image to create VMs with, if not specified, latest cos\_cloud/cos\_stable is used | `string` | `null` | no |
+| <a name="input_machine_image"></a> [machine\_image](#input\_machine\_image) | The machine image to create VMs with, if not specified, latest cos\_cloud/cos\_stable is used. To pin to one, use the following format: projects/cos-cloud/global/images/cos-stable-109-17800-147-54 | `string` | `null` | no |
 | <a name="input_machine_type"></a> [machine\_type](#input\_machine\_type) | The machine type to run Atlantis on | `string` | `"n2-standard-2"` | no |
 | <a name="input_name"></a> [name](#input\_name) | Custom name that's used during resource creation | `string` | n/a | yes |
 | <a name="input_network"></a> [network](#input\_network) | Name of the network | `string` | n/a | yes |

--- a/main.tf
+++ b/main.tf
@@ -82,6 +82,8 @@ module "container" {
   source  = "terraform-google-modules/container-vm/google"
   version = "~> 3.2"
 
+  cos_image_name = var.machine_image != null ? element(split("/", var.machine_image), length(split("/", var.machine_image)) - 1) : null
+
   container = {
     image = var.image
     securityContext = {

--- a/variables.tf
+++ b/variables.tf
@@ -25,7 +25,7 @@ variable "zone" {
 
 variable "machine_image" {
   type        = string
-  description = "The machine image to create VMs with, if not specified, latest cos_cloud/cos_stable is used"
+  description = "The machine image to create VMs with, if not specified, latest cos_cloud/cos_stable is used. To pin to one, use the following format: projects/cos-cloud/global/images/cos-stable-109-17800-147-54"
   default     = null
 }
 


### PR DESCRIPTION
continuation of: https://github.com/runatlantis/terraform-gce-atlantis/pull/149

## what
Achieve pinning of COS image by fixing behavior of machine_image var and input to downstream container module

## why
* Be able to pin image and not always use latest one

## references
* Closes #114 (which needs to be reopened to be closed again with this)
