### PR TITLE
chore: fix key file permissions custom-entrypoint.sh.tftpl in secure example

### DIFF
--- a/examples/secure-env-vars/custom-entrypoint.sh.tftpl
+++ b/examples/secure-env-vars/custom-entrypoint.sh.tftpl
@@ -30,7 +30,7 @@ gcloud config set component_manager/disable_update_check true
 gcloud config set metrics/environment github_docker_image
 gcloud --version
 
-gcloud secrets versions access latest --secret="${app_key_secret_name}" > "${key_file_path}" && chmod 400 "${key_file_path}" && chown 100 "${key_file_path}"
+gcloud secrets versions access latest --secret="${app_key_secret_name}" > "${key_file_path}" && chmod 600 "${key_file_path}" && chown 100 "${key_file_path}"
 
 export ATLANTIS_GH_APP_ID=$(gcloud secrets versions access latest --secret="${app_id_secret_name}")
 export ATLANTIS_GH_APP_KEY_FILE="${key_file_path}"


### PR DESCRIPTION
## what
* Allow the atlantis user to write to the key file

## why
* Prevent an error when the VM is recreated.
